### PR TITLE
Adding support for PowerShell 6+

### DIFF
--- a/com.absolute.api/com.absolute.api.psm1
+++ b/com.absolute.api/com.absolute.api.psm1
@@ -1,5 +1,8 @@
 ﻿##Version 1.8.1
 
+if ($PSVersionTable.PSVersion.Major -gt 5) {
+    $PSDefaultParameterValues['Invoke-RestMethod:SkipHeaderValidation'] = $true
+}
 
 # Authentication Functions
 function SHA256_Hash_Hex_Low_Encode(){


### PR DESCRIPTION
The authorization headers for the Absolute API require some characters that don't pass the strict header enforcement enabled by default in PowerShell 6+.

For reference: https://github.com/PowerShell/PowerShell/issues/5818

This is the easiest way to support PowerShell 6+ without changing any code.